### PR TITLE
fix usage instructions for hook installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ You'll also need to use at least version 0.10.0 of pre-commit.
 Add this to your `.pre-commit-config.yaml` in root of your repo:
 
 ```yaml
--   repo: local
+-   repo: https://github.com/askulkarni2/pre-commit-docker-jenkinslint
+    rev: master
     hooks:
     -   id: docker-jenkinslint
         language: docker_image


### PR DESCRIPTION
- pre-commit fails to install the hook if the rev or repo is missing

I got the following error until I fix the rev and repo, thus I'm suggesting an update of instructions to avoid this. Here is the initial error that led me to suggest this change :
```
pre-commit installed at .git/hooks/pre-commit
[WARNING] Unexpected key(s) present on https://github.com/jumanjihouse/pre-commit-hooks: sha
An error has occurred: InvalidConfigError:
==> File .pre-commit-config.yaml
==> At Config()
==> At key: repos
==> At Repository(repo='local')
==> At key: hooks
==> At Hook(id='docker-jenkinslint')
=====> Missing required key: name
Check the log at /Users/morgangeek/.cache/pre-commit/pre-commit.log
[WARNING] Unexpected key(s) present on https://github.com/jumanjihouse/pre-commit-hooks: sha
An error has occurred: InvalidConfigError:
==> File .pre-commit-config.yaml
==> At Config()
==> At key: repos
==> At Repository(repo='local')
==> At key: hooks
==> At Hook(id='docker-jenkinslint')
=====> Missing required key: name
Check the log at /Users/morgangeek/.cache/pre-commit/pre-commit.log
```